### PR TITLE
Rename from `Literal` to `NumericLiteral`

### DIFF
--- a/.tours/lexer.tour
+++ b/.tours/lexer.tour
@@ -43,7 +43,7 @@
     },
     {
       "file": "src/lex.ts",
-      "description": "Then it checks for numbers -- mini-typescript only supports integers, so the regexes are simple.\nNote that `scan` sets both `text` and `token` for numbers.\nAlso, mini-typescript doesn't support string, boolean or bigint literals, so it just calls the number literal token `Literal`.",
+      "description": "Then it checks for numbers -- mini-typescript only supports integers, so the regexes are simple.\nNote that `scan` sets both `text` and `token` for numbers.\nAlso, mini-typescript doesn't support string, boolean or bigint literals, so it just calls the number literal token `NumericLiteral`.",
       "line": 24
     },
     {

--- a/.tours/parser.tour
+++ b/.tours/parser.tour
@@ -13,7 +13,7 @@
     },
     {
       "file": "src/types.ts",
-      "description": "`Expression` is a union of all the expression types. For mini-typescript, that's just `Identifier`, `Literal` and `Assignment`.\n\nThe real Typescript compiler doesn't have unions for all its types -- for many it uses interface inheritance instead. That's mostly for historical reasons, because discriminated unions weren't available until Typescript 2.0.",
+      "description": "`Expression` is a union of all the expression types. For mini-typescript, that's just `Identifier`, `NumericLiteral` and `Assignment`.\n\nThe real Typescript compiler doesn't have unions for all its types -- for many it uses interface inheritance instead. That's mostly for historical reasons, because discriminated unions weren't available until Typescript 2.0.",
       "line": 38
     },
     {

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ npm run mtsc ./tests/singleVar.ts
 - [ ] Add arrow functions with an appropriate transform in ES5.
 - [ ] Add support for the lexer to report errors
   - report unterminated string literal error
-- [ ] Refactor: rename `Literal` to `NumericLiteral`
+- [x] Refactor: rename `Literal` to `NumericLiteral`

--- a/baselines/reference/emptyStatement.tree.baseline
+++ b/baselines/reference/emptyStatement.tree.baseline
@@ -25,7 +25,7 @@
         "text": "number"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },
@@ -43,7 +43,7 @@
         "text": "number"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 2
       }
     },

--- a/baselines/reference/firstLex.lex.baseline
+++ b/baselines/reference/firstLex.lex.baseline
@@ -1,6 +1,6 @@
 [
   [
-    "Literal",
+    "NumericLiteral",
     "1200"
   ],
   [
@@ -15,7 +15,7 @@
     "Unknown"
   ],
   [
-    "Literal",
+    "NumericLiteral",
     "14"
   ],
   [

--- a/baselines/reference/redeclare.tree.baseline
+++ b/baselines/reference/redeclare.tree.baseline
@@ -15,7 +15,7 @@
         "text": "x"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },
@@ -26,7 +26,7 @@
         "text": "x"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 2
       }
     },

--- a/baselines/reference/singleTypedVar.tree.baseline
+++ b/baselines/reference/singleTypedVar.tree.baseline
@@ -25,7 +25,7 @@
         "text": "string"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },

--- a/baselines/reference/singleVar.tree.baseline
+++ b/baselines/reference/singleVar.tree.baseline
@@ -15,7 +15,7 @@
         "text": "singleDeclaration"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },

--- a/baselines/reference/twoStatements.tree.baseline
+++ b/baselines/reference/twoStatements.tree.baseline
@@ -15,7 +15,7 @@
         "text": "arthurTwoShedsJackson"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },
@@ -28,7 +28,7 @@
           "text": "arthurTwoShedsJackson"
         },
         "value": {
-          "kind": "Literal",
+          "kind": "NumericLiteral",
           "value": 2
         }
       }

--- a/baselines/reference/twoTypedStatements.tree.baseline
+++ b/baselines/reference/twoTypedStatements.tree.baseline
@@ -19,7 +19,7 @@
         "text": "string"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 1
       }
     },
@@ -32,7 +32,7 @@
           "text": "s"
         },
         "value": {
-          "kind": "Literal",
+          "kind": "NumericLiteral",
           "value": 2
         }
       }

--- a/baselines/reference/typeAlias.tree.baseline
+++ b/baselines/reference/typeAlias.tree.baseline
@@ -78,7 +78,7 @@
         "text": "Nat"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 12
       }
     },
@@ -93,7 +93,7 @@
         "text": "Nat"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 13
       }
     },
@@ -141,7 +141,7 @@
         "text": "Not"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 14
       }
     },
@@ -152,7 +152,7 @@
         "text": "Nut"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 15
       }
     },
@@ -167,7 +167,7 @@
         "text": "Nut"
       },
       "init": {
-        "kind": "Literal",
+        "kind": "NumericLiteral",
         "value": 16
       }
     },

--- a/baselines/reference/varLex.lex.baseline
+++ b/baselines/reference/varLex.lex.baseline
@@ -10,7 +10,7 @@
     "Equals"
   ],
   [
-    "Literal",
+    "NumericLiteral",
     "1"
   ]
 ]

--- a/draft.md
+++ b/draft.md
@@ -16,7 +16,7 @@
   - \b - empty strings at the beginning and end of a word
   - \n - newline char
 - if at the end of input, it's a `EOF` token
-- if numbers, scan all numbers, add the number to the `text`, and the `Literal` token to the `token`
+- if numbers, scan all numbers, add the number to the `text`, and the `NumericLiteral` token to the `token`
 - if alphabetical chars, scan all chars, add the string to the `text`, and the token can be a `Keyword` or an `Identifier`
 - scan tokens like `Equals`, `Semicolon`, `Colon`, etc
 - if not in the list, it's a `Unknown` token
@@ -47,13 +47,13 @@ Source code: `s;`
 }
 ```
 
-#### Literal
+#### NumericLiteral
 
 Source code: `1;`
 
 ```json
 {
-  "kind": "Literal",
+  "kind": "NumericLiteral",
   "value": 1
 }
 ```
@@ -70,7 +70,7 @@ Source code: `example = 2;`
     "text": "example"
   },
   "value": {
-    "kind": "Literal",
+    "kind": "NumericLiteral",
     "value": 2
   }
 }
@@ -90,7 +90,7 @@ Source code: `example = 2;`
       "text": "arthurTwoShedsJackson"
     },
     "value": {
-      "kind": "Literal",
+      "kind": "NumericLiteral",
       "value": 2
     }
   }
@@ -113,7 +113,7 @@ Source code: `var s: string = 1;`
     "text": "string"
   },
   "init": {
-    "kind": "Literal",
+    "kind": "NumericLiteral",
     "value": 1
   }
 }
@@ -129,7 +129,7 @@ Source code: `var s = 1;`
     "text": "s"
   },
   "init": {
-    "kind": "Literal",
+    "kind": "NumericLiteral",
     "value": 1
   }
 }
@@ -167,7 +167,7 @@ Source code: `type Int = number; var int: Int = 10;`
     "text": "Int"
   },
   "init": {
-    "kind": "Literal",
+    "kind": "NumericLiteral",
     "value": 10
   }
 }

--- a/src/check.ts
+++ b/src/check.ts
@@ -56,7 +56,7 @@ export function check(module: Module) {
         }
         error(expression.pos, 'Could not resolve ' + expression.text);
         return errorType;
-      case Node.Literal:
+      case Node.NumericLiteral:
         return numberType;
       case Node.StringLiteral:
         return stringType;

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -41,7 +41,7 @@ function emitExpression(expression: Expression): string {
   switch (expression.kind) {
     case Node.Identifier:
       return expression.text;
-    case Node.Literal:
+    case Node.NumericLiteral:
       return '' + expression.value;
     case Node.StringLiteral:
       return expression.isSingleQuote

--- a/src/lex.ts
+++ b/src/lex.ts
@@ -34,7 +34,7 @@ export function lex(s: string): Lexer {
     } else if (/[0-9]/.test(s.charAt(pos))) {
       scanForward((c) => /[0-9]/.test(c));
       text = s.slice(start, pos);
-      token = Token.Literal;
+      token = Token.NumericLiteral;
     } else if (/[_a-zA-Z]/.test(s.charAt(pos))) {
       scanForward((c) => /[_a-zA-Z0-9]/.test(c));
       text = s.slice(start, pos);
@@ -140,7 +140,7 @@ export function lexAll(s: string) {
       case Token.EOF:
         return tokens;
       case Token.Identifier:
-      case Token.Literal:
+      case Token.NumericLiteral:
         tokens.push({ token: t, text: lexer.text() });
         break;
       default:

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -36,8 +36,8 @@ export function parse(lexer: Lexer): Module {
     const pos = lexer.pos();
     if (tryParseToken(Token.Identifier)) {
       return { kind: Node.Identifier, text: lexer.text(), pos };
-    } else if (tryParseToken(Token.Literal)) {
-      return { kind: Node.Literal, value: +lexer.text(), pos };
+    } else if (tryParseToken(Token.NumericLiteral)) {
+      return { kind: Node.NumericLiteral, value: +lexer.text(), pos };
     } else if (tryParseToken(Token.String)) {
       return {
         kind: Node.StringLiteral,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export enum Token {
   Type = 'Type',
   Return = 'Return',
   Equals = 'Equals',
-  Literal = 'Literal',
+  NumericLiteral = 'NumericLiteral',
   Identifier = 'Identifier',
   Newline = 'Newline',
   Semicolon = 'Semicolon',
@@ -26,7 +26,7 @@ export type Lexer = {
 
 export enum Node {
   Identifier,
-  Literal,
+  NumericLiteral,
   Assignment,
   ExpressionStatement,
   Var,
@@ -44,15 +44,19 @@ export interface Location {
   pos: number;
 }
 
-export type Expression = Identifier | Literal | Assignment | StringLiteral;
+export type Expression =
+  | Identifier
+  | NumericLiteral
+  | Assignment
+  | StringLiteral;
 
 export type Identifier = Location & {
   kind: Node.Identifier;
   text: string;
 };
 
-export type Literal = Location & {
-  kind: Node.Literal;
+export type NumericLiteral = Location & {
+  kind: Node.NumericLiteral;
   value: number;
 };
 


### PR DESCRIPTION
Now that we have `StringLiteral`s, using `Literal` for number doesn't make sense. This PR renames it to `NumericLiteral`.